### PR TITLE
[FIX] Sounds & Images not loading from folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Section Order:
 ### Removed
 -->
 
+## [2.0.1] 2025-11-24
+
+### Fixed
+
+- **Resource loading:** Completely rewritten `get_resource_path()` — the application now always reads resources from the running executable. This ensures `img/` and `sound/` are consistently loaded in both development and distribution builds.
+- **Sound handling:** Corrected `SOUND_FOLDER` in `evealert/constants.py` to `sound`, so custom WAV files like `alarm.wav` are properly located and played.
+
 ## [2.0.0] 2025-11-22
 
 Big Thanks to [@Gotarr](https://github.com/Gotarr) for improving the whole EVE-Alert System with many QoL changes, fixes, optimations

--- a/evealert/constants.py
+++ b/evealert/constants.py
@@ -24,7 +24,7 @@ STATUS_CHECK_INTERVAL = 1000  # Status check interval (ms)
 AUDIO_CHANNELS = 2  # Stereo output
 
 # File Paths
-IMG_FOLDER = "evealert/img"
+IMG_FOLDER = "img"
 SOUND_FOLDER = "sound"
 ALARM_SOUND_FILE = "alarm.wav"
 FACTION_SOUND_FILE = "faction.wav"


### PR DESCRIPTION
Please include a summary of the changes and the related issue number (if applicable).

## Description
### Fixed

- **Resource loading:** Completely rewritten `get_resource_path()` — the application now always reads resources from the running executable. This ensures `img/` and `sound/` are consistently loaded in both development and distribution builds.
- **Sound handling:** Corrected `SOUND_FOLDER` in `evealert/constants.py` to `sound`, so custom WAV files like `alarm.wav` are properly located and played.


### Type of Changes
Please select the type of changes made in this pull request:
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation Update
- [ ] Other (please specify):

### Checklist
Please ensure the following before submitting your pull request:
- [x] I have read the [contributing guidelines](https://github.com/geuthur/EVE-Alert-Opensource/blob/main/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] All new and existing tests passed.
